### PR TITLE
Lower the Go version requirement and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  GO_VERSION: '1.22'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Test
+      run: |
+        go test

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GNU command line argument rules:
 *See also [github.com/tdewolff/prompt](https://github.com/tdewolff/prompt) for a command line prompter.*
 
 ## Installation
-Make sure you have [Git](https://git-scm.com/) and [Go](https://golang.org/dl/) (1.13 or higher) installed, run
+Make sure you have [Git](https://git-scm.com/) and [Go](https://golang.org/dl/) (1.22 or higher) installed, run
 ```
 mkdir Project
 cd Project

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tdewolff/argp
 
-go 1.24.1
+go 1.22
 
 require (
 	github.com/jmoiron/sqlx v1.4.0


### PR DESCRIPTION
argp requires the latest Go 1.24.1 but passes tests with earlier versions. Could you lower the required Go version to 1.22? That is the version packaged for Ubuntu 24.04, the current LTS, so it would be convenient for Ubuntu users. This PR lowers the required Go version and also adds Linux/Mac/Windows CI to ensure cross-platform and version compatibility.