### PR TITLE
Exit with status 2 on bad usage

### DIFF
--- a/argp.go
+++ b/argp.go
@@ -72,7 +72,7 @@ func New(description string) *Argp {
 	return NewCmd(nil, description)
 }
 
-// NewCmd returns a new command parser that invokes the Run method of the passed command structure. The `Argp.Parse()` function will not return and call either os.Exit(0) or os.Exit(1).
+// NewCmd returns a new command parser that invokes the Run method of the passed command structure. The `Argp.Parse()` function will not return and will call os.Exit() with 0, 1 or 2 as the argument.
 func NewCmd(cmd Cmd, description string) *Argp {
 	argp := &Argp{
 		Cmd:         cmd,
@@ -588,7 +588,7 @@ func (argp *Argp) Parse() {
 	if err != nil {
 		fmt.Printf("%v\n\n", err)
 		cmd.PrintHelp()
-		os.Exit(1)
+		os.Exit(2)
 	} else if cmd.help || cmd != argp && cmd.Cmd == nil {
 		cmd.PrintHelp()
 		os.Exit(0)
@@ -600,16 +600,18 @@ func (argp *Argp) Parse() {
 			}
 			fmt.Printf("%s: %v\n\n", msg, strings.Join(rest, " "))
 			cmd.PrintHelp()
-			os.Exit(1)
+			os.Exit(2)
 		} else if err := cmd.Cmd.Run(); err != nil {
+			// Exit with status 2 on bad usage and with status 1 when we don't know the nature of the error.
 			if err == ShowUsage {
 				cmd.PrintHelp()
 			} else if argp.Error != nil {
 				argp.Error.Println(err)
 			} else {
 				fmt.Printf("ERROR: %v\n", err)
+				os.Exit(1)
 			}
-			os.Exit(1)
+			os.Exit(2)
 		} else {
 			os.Exit(0)
 		}


### PR DESCRIPTION
This mimics GNU Bash built-ins and Coreutils more closely. It allows the user to tell usage and other errors apart by their exit status.

From the [Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html):

> All of the Bash builtins return an exit status of zero if they succeed and a non-zero status on failure, so they may be used by the conditional and list constructs. All builtins return an exit status of 2 to indicate incorrect usage, generally invalid options or missing arguments.

From the GNU [ls(1)](https://man7.org/linux/man-pages/man1/ls.1.htmlls) manual:

```none
   Exit status:
       0      if OK,
       1      if minor problems (e.g., cannot access subdirectory),
       2      if serious trouble (e.g., cannot access command-line
              argument).
```