### PR TITLE
Document and test `AddRest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ func main() {
     argp.AddOpt(argp.Count{&verbose}, "v", "verbose", "Increase verbosity, eg. -vvv")
     argp.AddOpt(&output, "o", "output", "Output file name")
     argp.AddOpt(&size, "", "size", "Image size")
-    argp.AddArg(&input, "input", "Input file name size")
+    argp.AddArg(&input, "input", "Input file name")
+    argp.AddRest(&files, "files", "Additional input files")
     argp.Parse()
 
     // ...
@@ -110,6 +111,15 @@ type Command struct {
 func (cmd *Command) Run() error {
     // ...
 }
+```
+
+### Arguments
+```go
+var input string
+cmd.AddArg(&input, "input", "Input file name")
+
+var files []string
+cmd.AddRest(&files, "files", "Additional input files")
 ```
 
 ### Options

--- a/argp_test.go
+++ b/argp_test.go
@@ -315,6 +315,20 @@ func TestArgpAdd(t *testing.T) {
 	test.Error(t, err)
 }
 
+func TestArgpAddRest(t *testing.T) {
+	var rest []string
+	argp := New("description")
+	argp.AddRest(&rest, "rest", "description")
+
+	_, _, err := argp.parse([]string{"file1.txt", "file2.txt", "file3.txt"})
+	test.Error(t, err)
+	test.T(t, rest, []string{"file1.txt", "file2.txt", "file3.txt"})
+
+	_, _, err = argp.parse([]string{})
+	test.Error(t, err)
+	test.T(t, rest, []string{})
+}
+
 func TestArgpUTF8(t *testing.T) {
 	var v bool
 	argp := New("description")


### PR DESCRIPTION
It took me some time to realize `AddArg` with a string slice wasn't what I needed for multiple filename arguments and to find `AddRest`. This PR documents `AddRest` in the readme and adds a test for it.